### PR TITLE
Support Rocq 9.0-9.2

### DIFF
--- a/.github/workflows/deploy-coqdoc.yml
+++ b/.github/workflows/deploy-coqdoc.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build coqdoc
         uses: coq-community/docker-coq-action@v1
         with:
-          custom_image: 'coqorg/coq:dev'
+          custom_image: 'rocq/rocq-prover:dev'
           custom_script: |
             {{before_install}}
             startGroup "Build mmaps dependencies"
@@ -27,7 +27,7 @@ jobs:
               opam install -y -j "$(nproc)" coq-mmaps --deps-only
             endGroup
             startGroup "Add permissions"
-              sudo chown -R coq:coq .
+              sudo chown -R 1000:1000 .
             endGroup
             startGroup "Build coqdoc"
               make -j "$(nproc)"

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -17,17 +18,18 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
           - 'coqorg/coq:8.20'
           - 'coqorg/coq:8.19'
           - 'coqorg/coq:8.18'
           - 'coqorg/coq:8.17'
           - 'coqorg/coq:8.16'
-          - 'coqorg/coq:8.15'
-          - 'coqorg/coq:8.14'
+          - 'rocq/rocq-prover:dev'
+          - 'rocq/rocq-prover:9.2'
+          - 'rocq/rocq-prover:9.1'
+          - 'rocq/rocq-prover:9.0'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: 'coq-mmaps.opam'

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ that is meant to complement the Stdlib's MSet library.
 - Author(s):
   - Pierre Letouzey (initial)
   - Andrew W. Appel
-- Coq-community maintainer(s):
+- Rocq-community maintainer(s):
   - Pierre Letouzey ([**@letouzey**](https://github.com/letouzey))
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU Lesser General Public License v2.1 only](LICENSE)
-- Compatible Coq versions: 8.14 and later
+- Compatible Rocq/Coq versions: 8.16 and later
 - Additional dependencies: none
-- Coq namespace: `MMaps`
+- Rocq/Coq namespace: `MMaps`
 - Related publication(s):
   - [Efficient Verified Red-Black Trees](https://www.cs.princeton.edu/~appel/papers/redblack.pdf) 
   - [Functors for Proofs and Programs](https://hal.inria.fr/hal-00150913) doi:[10.1007/978-3-540-24725-8_26](https://doi.org/10.1007/978-3-540-24725-8_26)
@@ -51,15 +51,19 @@ The easiest way to install the latest released version of Modular Finite Maps ov
 is via [OPAM](https://opam.ocaml.org/doc/Install.html):
 
 ```shell
-opam repo add coq-released https://coq.inria.fr/opam/released
+opam repo add rocq-released https://rocq-prover.org/opam/released
 opam install coq-mmaps
 ```
 
-To instead build and install manually, do:
+To instead build and install manually, you need to make sure that all the
+libraries this development depends on are installed.  The easiest way to do that
+is still to rely on opam:
 
 ``` shell
 git clone https://github.com/coq-community/coq-mmaps.git
 cd coq-mmaps
+opam repo add rocq-released https://rocq-prover.org/opam/released
+opam install --deps-only .
 make   # or make -j <number-of-cores-on-your-machine> 
 make install
 ```

--- a/coq-mmaps.opam
+++ b/coq-mmaps.opam
@@ -21,7 +21,7 @@ that is meant to complement the Stdlib's MSet library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.14"}
+  "coq" {>= "8.16"}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -42,18 +42,21 @@ license:
   identifier: LGPL-2.1-only
 
 supported_coq_versions:
-  text: 8.14 and later
-  opam: '{>= "8.14"}'
+  text: 8.16 and later
+  opam: '{>= "8.16"}'
 
 tested_coq_opam_versions:
-- version: 'dev'
 - version: '8.20'
 - version: '8.19'
 - version: '8.18'
 - version: '8.17'
 - version: '8.16'
-- version: '8.15'
-- version: '8.14'
+
+tested_rocq_opam_versions:
+- version: 'dev'
+- version: '9.2'
+- version: '9.1'
+- version: '9.0'
 
 namespace: MMaps
 

--- a/theories/Facts.v
+++ b/theories/Facts.v
@@ -1759,7 +1759,7 @@ Section Elt.
   Proof.
   intros x.
   rewrite fold_spec_right, bindings_o, filter_spec.
-  rewrite findA_rev, filter_rev by apply NoDupA_filter, bindings_spec2w.
+  rewrite findA_rev, Utils.filter_rev by apply NoDupA_filter, bindings_spec2w.
   change K.t with key in *.
   induction (rev (bindings m)) as [|(y,e) l IH]; simpl.
   - now rewrite empty_o.
@@ -2653,7 +2653,7 @@ assert (forall tab k, eqv (fold g tab u) (f (get k tab) (fold g (remove k tab) u
       InA (keyb_eq (elt:=elt)) (k', y) (rev (bindings (remove k tab))) <->
       InA (keyb_eq (elt:=elt)) (k', y)
         (List.filter (fun p : K.t * elt => negb (eqb (fst p) k)) (rev (bindings tab)))).
-        intros; rewrite <- filter_rev, !InA_rev. auto.
+        intros; rewrite <- Utils.filter_rev, !InA_rev. auto.
     clear H0.
     pose proof (bindings_3w tab).
     pose proof (bindings_3w (remove k tab)).

--- a/theories/RBTproofs.v
+++ b/theories/RBTproofs.v
@@ -40,11 +40,16 @@ Local Notation Bk := (@Node _ Black).
     - the black depth at each node is the same along all paths.
     The black depth is here an argument of the predicate. *)
 
+(* LATER: `Scheme rbt_ind := Induction for rbt Sort Prop` raised a universe
+   anomaly ("Universe ... undefined") in Rocq 9.1, so instead of using `Scheme`
+   explicitly we enable automatic elimination scheme generation for `rbt`. *)
+Local Set Elimination Schemes.
 Inductive rbt elt : nat -> tree elt -> Prop :=
  | RB_Leaf : rbt 0 Leaf
  | RB_Rd n l k e r :
    notred l -> notred r -> rbt n l -> rbt n r -> rbt n (Rd l k e r)
  | RB_Bk n l k e r : rbt n l -> rbt n r -> rbt (S n) (Bk l k e r).
+Local Unset Elimination Schemes.
 
 (** A red-red tree is almost a red-black tree, except that it has
     a _red_ root node which _may_ have red children. Note that a
@@ -70,7 +75,6 @@ Class Rbt elt (t:tree elt) :=  RBT : exists d, rbt d t.
 
 (** ** Basic tactics and results about red-black trees *)
 
-Scheme rbt_ind := Induction for rbt Sort Prop.
 Local Hint Constructors rbt rrt arbt : map.
 Local Hint Extern 0 (notred _) => (exact I) : map.
 Ltac invrb := intros; inv rrt; inv rbt; try contradiction.


### PR DESCRIPTION
* RBTproofs.v:
  `Scheme rbt_ind := Induction for rbt Sort Prop` raises a universe
  anomaly ("Universe GenTree.NN undefined") in Rocq 9.1 (but not 9.0 nor 9.2).
  Work around it by temporarily enabling automatic induction schemes.

* theories/Facts.v (filter_alt, relate_fold_add):
  Qualify `filter_rev` to avoid a clash with Rocq 9's stdlib.

* meta.yml, coq-mmaps.opam (tested_coq_opam_versions):
  Drop 8.14 and 8.15 (they are not installable any more).

* README, .github/*.yml: Adjust to latest template